### PR TITLE
create a new http response errors for XML bodies

### DIFF
--- a/tweet.go
+++ b/tweet.go
@@ -211,6 +211,17 @@ func (t *TweetRecentSearch) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// HTTPError is a response error where the body is not JSON, but XML.  This commonly seen in 404 errors.
+type HTTPError struct {
+	Status     string
+	StatusCode int
+	URL        string
+}
+
+func (h *HTTPError) Error() string {
+	return fmt.Sprintf("tweet [%s] status: %s code: %d", h.URL, h.Status, h.StatusCode)
+}
+
 // TweetError is the group of errors in a response
 type TweetError struct {
 	Parameters interface{} `json:"parameters"`
@@ -318,7 +329,11 @@ func (t *Tweet) Lookup(ctx context.Context, ids []string, options TweetFieldOpti
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -371,7 +386,11 @@ func (t *Tweet) RecentSearch(ctx context.Context, query string, searchOpts Tweet
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet recent search response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -427,7 +446,11 @@ func (t *Tweet) ApplyFilteredStreamRules(ctx context.Context, rules TweetSearchS
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet search stream rules response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -469,7 +492,11 @@ func (t *Tweet) FilteredStreamRules(ctx context.Context, ids []string) (*TweetSe
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet search stream rules response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -504,7 +531,11 @@ func (t *Tweet) FilteredStream(ctx context.Context, options TweetFieldOptions) (
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -539,7 +570,11 @@ func (t *Tweet) SampledStream(ctx context.Context, options TweetFieldOptions) (T
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("tweet lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -585,7 +620,11 @@ func (t *Tweet) HideReplies(ctx context.Context, id string, hidden bool) error {
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return fmt.Errorf("tweet lookup response error decode: %w", err)
+			return &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return e

--- a/tweet.go
+++ b/tweet.go
@@ -219,7 +219,7 @@ type HTTPError struct {
 }
 
 func (h *HTTPError) Error() string {
-	return fmt.Sprintf("tweet [%s] status: %s code: %d", h.URL, h.Status, h.StatusCode)
+	return fmt.Sprintf("twitter [%s] status: %s code: %d", h.URL, h.Status, h.StatusCode)
 }
 
 // TweetError is the group of errors in a response

--- a/user.go
+++ b/user.go
@@ -170,7 +170,11 @@ func (u *User) Lookup(ctx context.Context, ids []string, fieldOpts UserFieldOpti
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -227,7 +231,11 @@ func (u *User) LookupUsername(ctx context.Context, usernames []string, fieldOpts
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := decoder.Decode(e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -282,7 +290,11 @@ func (u *User) LookupFollowing(ctx context.Context, id string, followOpts UserFo
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := json.Unmarshal(body, e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -342,7 +354,11 @@ func (u *User) LookupFollowers(ctx context.Context, id string, followOpts UserFo
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := json.Unmarshal(body, e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -402,7 +418,11 @@ func (u *User) Tweets(ctx context.Context, id string, tweetOpts UserTimelineOpts
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := json.Unmarshal(body, e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e
@@ -444,7 +464,11 @@ func (u *User) Mentions(ctx context.Context, id string, tweetOpts UserTimelineOp
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("user lookup following reading body: %w", err)
+		return nil, &HTTPError{
+			Status:     resp.Status,
+			StatusCode: resp.StatusCode,
+			URL:        resp.Request.URL.String(),
+		}
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/user.go
+++ b/user.go
@@ -464,17 +464,17 @@ func (u *User) Mentions(ctx context.Context, id string, tweetOpts UserTimelineOp
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, &HTTPError{
-			Status:     resp.Status,
-			StatusCode: resp.StatusCode,
-			URL:        resp.Request.URL.String(),
-		}
+		return nil, fmt.Errorf("user lookup following reading body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
 		e := &TweetErrorResponse{}
 		if err := json.Unmarshal(body, e); err != nil {
-			return nil, fmt.Errorf("user lookup response error decode: %w", err)
+			return nil, &HTTPError{
+				Status:     resp.Status,
+				StatusCode: resp.StatusCode,
+				URL:        resp.Request.URL.String(),
+			}
 		}
 		e.StatusCode = resp.StatusCode
 		return nil, e


### PR DESCRIPTION
At times there are errors returned from the API that are not JSON, yet XML.  This will fail a JSON unmarshaling and the error is not very informative.  

To address this, a new error has been created, `HTTPError` which will contain the URL, status and status code.  By using `errors.As`, it can provide some better information to the caller.