### PR TITLE
Add next_token to TweetRecentCount

### DIFF
--- a/v2/tweet_counts.go
+++ b/v2/tweet_counts.go
@@ -9,7 +9,8 @@ type TweetRecentCountsResponse struct {
 
 // TweetRecentCountsMeta contains the meta data from the recent counts information
 type TweetRecentCountsMeta struct {
-	TotalTweetCount int `json:"total_tweet_count"`
+	TotalTweetCount int    `json:"total_tweet_count"`
+	NextToken       string `json:"next_token"`
 }
 
 // TweetCount is the object on the tweet counts endpoints

--- a/v2/tweet_counts_options.go
+++ b/v2/tweet_counts_options.go
@@ -24,6 +24,7 @@ type TweetRecentCountsOpts struct {
 	SinceID     string
 	UntilID     string
 	Granularity Granularity
+	NextToken   string
 }
 
 func (t TweetRecentCountsOpts) addQuery(req *http.Request) {
@@ -42,6 +43,9 @@ func (t TweetRecentCountsOpts) addQuery(req *http.Request) {
 	}
 	if len(t.Granularity) > 0 {
 		q.Add("granularity", string(t.Granularity))
+	}
+	if len(t.NextToken) > 0 {
+		q.Add("next_token", t.NextToken)
 	}
 	if len(q) > 0 {
 		req.URL.RawQuery = q.Encode()


### PR DESCRIPTION
Actually `next_token` could've been sent to and responded from `GET /2/tweets/counts/recent` typically when `minute` would be set for `granularity` paremeter. It's not documented in the official documentation though.