### PR TITLE
updated the keep alive to to 20 sec

### DIFF
--- a/v2/tweet_stream.go
+++ b/v2/tweet_stream.go
@@ -28,7 +28,7 @@ const (
 	ErrorMessageType SystemMessageType = "error"
 
 	tweetStart  = "data"
-	keepAliveTO = 11 * time.Second
+	keepAliveTO = 21 * time.Second
 
 	// TweetErrorType represents the tweet stream errors
 	TweetErrorType StreamErrorType = "tweet"


### PR DESCRIPTION
Updating the TO for keep alive to 20 secs per [docs](https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/handling-disconnections).

Tho original keep alive TO was 10 sec based of this [doc](https://developer.twitter.com/en/docs/tutorials/consuming-streaming-data).