### PR TITLE
Matching rules support

### DIFF
--- a/v2/tweet_raw.go
+++ b/v2/tweet_raw.go
@@ -57,9 +57,10 @@ type UserTimelineMeta struct {
 }
 
 type tweetraw struct {
-	Tweet    *TweetObj         `json:"data"`
-	Includes *TweetRawIncludes `json:"includes"`
-	Errors   []*ErrorObj       `json:"errors"`
+	Tweet         *TweetObj         `json:"data"`
+	Includes      *TweetRawIncludes `json:"includes"`
+	Errors        []*ErrorObj       `json:"errors"`
+	MatchingRules []*MatchingRule   `json:"matching_rules"`
 }
 
 type MatchingRule struct {
@@ -72,7 +73,7 @@ type TweetRaw struct {
 	Tweets        []*TweetObj       `json:"data"`
 	Includes      *TweetRawIncludes `json:"includes,omitempty"`
 	Errors        []*ErrorObj       `json:"errors,omitempty"`
-	MatchingRules []MatchingRule    `json:"matching_rules"`
+	MatchingRules []*MatchingRule   `json:"matching_rules"`
 	dictionaries  map[string]*TweetDictionary
 }
 

--- a/v2/tweet_raw.go
+++ b/v2/tweet_raw.go
@@ -62,12 +62,18 @@ type tweetraw struct {
 	Errors   []*ErrorObj       `json:"errors"`
 }
 
+type MatchingRule struct {
+	Id  string `json:"id"`
+	Tag string `json:"tag"`
+}
+
 // TweetRaw is the raw response from the tweet lookup endpoint
 type TweetRaw struct {
-	Tweets       []*TweetObj       `json:"data"`
-	Includes     *TweetRawIncludes `json:"includes,omitempty"`
-	Errors       []*ErrorObj       `json:"errors,omitempty"`
-	dictionaries map[string]*TweetDictionary
+	Tweets        []*TweetObj       `json:"data"`
+	Includes      *TweetRawIncludes `json:"includes,omitempty"`
+	Errors        []*ErrorObj       `json:"errors,omitempty"`
+	MatchingRules []MatchingRule    `json:"matching_rules"`
+	dictionaries  map[string]*TweetDictionary
 }
 
 // TweetDictionaries create a map of tweet dictionaries from the raw tweet response

--- a/v2/tweet_stream.go
+++ b/v2/tweet_stream.go
@@ -354,6 +354,7 @@ func (ts *TweetStream) handleTweet(decoder *json.Decoder) {
 	raw.Tweets[0] = single.Tweet
 	raw.Includes = single.Includes
 	raw.Errors = single.Errors
+	raw.MatchingRules = single.MatchingRules
 
 	tweetMsg := &TweetMessage{
 		Raw: raw,


### PR DESCRIPTION
On the filtered-stream API is present the `matching_rules` field that it is currently ignored by the current API. I simply added this new field to the struct since I needed it.
Until this change is not merged in the main branch I have to use my forked repo.

I didn't add any test but if you need it I can do that too.

[Twitter doc](https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/api-reference/get-tweets-search-stream)